### PR TITLE
api client additions

### DIFF
--- a/lib/passmarked.js
+++ b/lib/passmarked.js
@@ -28,9 +28,9 @@ module.exports = {
   submit: function(address, done) {
     http.request({
       hostname: 'api.passmarked.com',
-      method: 'POST', // ???
-      path: '/submit', // ???
-      headers: {} // ???
+      method: 'POST',
+      path: '/submit',
+      headers: {'Content-Type': 'x-www-form-urlencoded'}
     }, function(res) {
       var json = '';
       res.on('data', function(data) {
@@ -39,7 +39,43 @@ module.exports = {
         done(null, JSON.parse(json));
       });
     }).on('error', function(err) {
+      process.emit('log:error', [
+        _.r_bg(' ✔ api.passmarked.com: '),
+        'host unreachable'
+      ]);
       done(err);
-    }).end(/* ??? */);
+    }).end('url=' + address);
+  },
+  stats: function(done) {
+    http.get('http://api.passmarked.com/stats', function(res) {
+      var json = '';
+      res.on('data', function(data) {
+        json += data;
+      }).on('end', function() {
+        done(null, JSON.parse(json));
+      });
+    }).on('error', function(err) {
+      process.emit('log:error', [
+        _.r_bg(' ✔ api.passmarked.com: '),
+        'host unreachable'
+      ]);
+      done(err);
+    });
+  },
+  report: function(id, done) {
+    http.get('http://api.passmarked.com/reports/' + id, function(res) {
+      var json = '';
+      res.on('data', function(data) {
+        json += data;
+      }).on('end', function() {
+        done(null, JSON.parse(json));
+      });
+    }).on('error', function(err) {
+      process.emit('log:error', [
+        _.r_bg(' ✔ api.passmarked.com: '),
+        'host unreachable'
+      ]);
+      done(err);
+    });
   }
 };

--- a/lib/passmarked.js
+++ b/lib/passmarked.js
@@ -44,7 +44,7 @@ module.exports = {
         'host unreachable'
       ]);
       done(err);
-    }).end('url=' + address);
+    }).end(encodeURIComponent('url=' + address));
   },
   stats: function(done) {
     http.get('http://api.passmarked.com/stats', function(res) {


### PR DESCRIPTION
added `stats`, `submit` and `report`

- not yet sure if `submit` will work with `x-www-form-urlencoded` as the `web` implementation uses `form-data`.
- submitting a domain for testing will yield a report id which we can then use to retrieve results for the domain.
- stats route will be nice to display at app startup or as an option. will also be useful in checking the service status.